### PR TITLE
Change GA gtag  to GTM, Add GSC

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -1,29 +1,30 @@
 doctype html
 
-//- Google Tag Manager(Google Analytics)
-script.
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PK63JQ2');
+head
+  //- Google Tag Manager(Google Analytics)
+  script.
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PK63JQ2');
 
-title MIRAI BASE
-meta(charset='utf-8')
-meta(name='description' content='コワーキングスペース MIRAI BASEは、現在函館で多方面に活躍する方々や、これから活躍していく方々の活動拠点となるための共同作業場です。個人での作業やグループでの作業、フィールドワークの拠点、共通の技術を用いる仲間とのコミュニケーション、ものづくりなどにご利用ください。')
-meta(name="keywords", content='コワーキングスペース,作業場,MIRAIBASE,未来ベース,ミライベース,貸しオフィス')
-meta(name='viewport' content='width=device-width,initial-scale=1.0')
+  title MIRAI BASE
+  meta(charset='utf-8')
+  meta(name='description' content='コワーキングスペース MIRAI BASEは、現在函館で多方面に活躍する方々や、これから活躍していく方々の活動拠点となるための共同作業場です。個人での作業やグループでの作業、フィールドワークの拠点、共通の技術を用いる仲間とのコミュニケーション、ものづくりなどにご利用ください。')
+  meta(name="keywords", content='コワーキングスペース,作業場,MIRAIBASE,未来ベース,ミライベース,貸しオフィス')
+  meta(name='viewport' content='width=device-width,initial-scale=1.0')
 
-//- meta(name='robots' content='noindex')
-link(rel="icon" type="image/png", href="./images/favicon.png")
-link(rel="apple-touch-icon" href="./images/apple-touch-icon.png")
+  //- meta(name='robots' content='noindex')
+  link(rel="icon" type="image/png", href="./images/favicon.png")
+  link(rel="apple-touch-icon" href="./images/apple-touch-icon.png")
 
-meta(name='og:title' content='コワーキングスペース MIRAI BASE')
-meta(property='og:type', content='website')
-meta(property='og:url', content='https://miraibase.jp/')
-meta(property='og:image', content='https://miraibase.jp/ogimage.png')
-meta(property='og:site_name', content='コワーキングスペース MIRAI BASE')
-meta(property='og:description', content='MIRAI BASEは、函館で多方面に活躍する方々や、これから活躍していく方々の活動拠点となるための共同作業場です。')
-meta(name='twitter:card', content='summary')
-meta(name='twitter:title' content='コワーキングスペース MIRAI BASE')
-meta(name='twitter:text:title' content='コワーキングスペース MIRAI BASE')
-meta(name='google-site-verification', content='kqErxoADTB_P6UWPz_i5AUn5yk92sazePhYIxZYR09E')
+  meta(name='og:title' content='コワーキングスペース MIRAI BASE')
+  meta(property='og:type', content='website')
+  meta(property='og:url', content='https://miraibase.jp/')
+  meta(property='og:image', content='https://miraibase.jp/ogimage.png')
+  meta(property='og:site_name', content='コワーキングスペース MIRAI BASE')
+  meta(property='og:description', content='MIRAI BASEは、函館で多方面に活躍する方々や、これから活躍していく方々の活動拠点となるための共同作業場です。')
+  meta(name='twitter:card', content='summary')
+  meta(name='twitter:title' content='コワーキングスペース MIRAI BASE')
+  meta(name='twitter:text:title' content='コワーキングスペース MIRAI BASE')
+  meta(name='google-site-verification', content='kqErxoADTB_P6UWPz_i5AUn5yk92sazePhYIxZYR09E')
 
 #jump
   .toTop

--- a/src/index.pug
+++ b/src/index.pug
@@ -1,5 +1,9 @@
 doctype html
 
+//- Google Tag Manager(Google Analytics)
+script.
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PK63JQ2');
+
 title MIRAI BASE
 meta(charset='utf-8')
 meta(name='description' content='コワーキングスペース MIRAI BASEは、現在函館で多方面に活躍する方々や、これから活躍していく方々の活動拠点となるための共同作業場です。個人での作業やグループでの作業、フィールドワークの拠点、共通の技術を用いる仲間とのコミュニケーション、ものづくりなどにご利用ください。')
@@ -19,6 +23,7 @@ meta(property='og:description', content='MIRAI BASEは、函館で多方面に�
 meta(name='twitter:card', content='summary')
 meta(name='twitter:title' content='コワーキングスペース MIRAI BASE')
 meta(name='twitter:text:title' content='コワーキングスペース MIRAI BASE')
+meta(name='google-site-verification', content='kqErxoADTB_P6UWPz_i5AUn5yk92sazePhYIxZYR09E')
 
 #jump
   .toTop
@@ -209,10 +214,7 @@ footer.bc-green.section
 
 script(src='app.js')
 
-//- Global site tag (gtag.js) - Google Analytics
-script(async='', src='https://www.googletagmanager.com/gtag/js?id=UA-147982265-1')
-script.
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-147982265-1');
+// Google Tag Manager (noscript)
+noscript
+  iframe(src='https://www.googletagmanager.com/ns.html?id=GTM-PK63JQ2', height='0', width='0', style='display:none;visibility:hidden')
+// End Google Tag Manager (noscript)


### PR DESCRIPTION
# 目的
Google Analyticsの標準タグはgtagだが、parcelの都合上gtagが動作しない
ので、Google Tag Managerに差し替えてGoogle Analyticsを有効化する

さらに、Google Search Console用の認証タグを追加する

